### PR TITLE
Corrected imports to match current go release

### DIFF
--- a/httpjsonrpc/httpjsonrpcClient.go
+++ b/httpjsonrpc/httpjsonrpcClient.go
@@ -5,42 +5,41 @@ package httpjsonrpc
 // license that can be found in the LICENSE file.
 
 import (
-    "json"
-    "io/ioutil"
-    "log"
-    "http"
-    "strings"
-    "os"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
 )
 
-func Call(address string, method string, id interface{}, params []interface{})(map[string]interface{}, os.Error){
-    data, err := json.Marshal(map[string]interface{}{
-        "method": method,
-        "id":     id,
-        "params": params,
-    })
-    if err != nil {
-        log.Fatalf("Marshal: %v", err)
-    	return nil, err
-    }
-    resp, err := http.Post(address,
-        "application/json", strings.NewReader(string(data)))
-    if err != nil {
-        log.Fatalf("Post: %v", err)
-    	return nil, err
-    }
-    defer resp.Body.Close()
-    body, err := ioutil.ReadAll(resp.Body)
-    if err != nil {
-        log.Fatalf("ReadAll: %v", err)
-    	return nil, err
-    }
-    result := make(map[string]interface{})
-    err = json.Unmarshal(body, &result)
-    if err != nil {
-        log.Fatalf("Unmarshal: %v", err)
-    	return nil, err
-    }
-    //log.Println(result)
-    return result, nil
+func Call(address string, method string, id interface{}, params []interface{}) (map[string]interface{}, error) {
+	data, err := json.Marshal(map[string]interface{}{
+		"method": method,
+		"id":     id,
+		"params": params,
+	})
+	if err != nil {
+		log.Fatalf("Marshal: %v", err)
+		return nil, err
+	}
+	resp, err := http.Post(address,
+		"application/json", strings.NewReader(string(data)))
+	if err != nil {
+		log.Fatalf("Post: %v", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("ReadAll: %v", err)
+		return nil, err
+	}
+	result := make(map[string]interface{})
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		log.Fatalf("Unmarshal: %v", err)
+		return nil, err
+	}
+	//log.Println(result)
+	return result, nil
 }

--- a/httpjsonrpc/httpjsonrpcServer.go
+++ b/httpjsonrpc/httpjsonrpcServer.go
@@ -4,114 +4,114 @@ package httpjsonrpc
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import(
-	"http"
+import (
+	"encoding/json"
 	"io/ioutil"
 	"log"
-	"json"
+	"net/http"
 )
 
 //multiplexer that keeps track of every function to be called on specific rpc call
 type ServeMux struct {
-		m map[string]func(*http.Request, map[string]interface{})(map[string]interface{})
-		defaultFunction func (http.ResponseWriter, *http.Request)
+	m               map[string]func(*http.Request, map[string]interface{}) map[string]interface{}
+	defaultFunction func(http.ResponseWriter, *http.Request)
 }
 
 //an instance of the multiplexer
 var mainMux ServeMux
 
 //a function to register functions to be called for specific rpc calls
-func HandleFunc(pattern string, handler func(*http.Request, map[string]interface{})(map[string]interface{})){
-	mainMux.m[pattern]=handler
+func HandleFunc(pattern string, handler func(*http.Request, map[string]interface{}) map[string]interface{}) {
+	mainMux.m[pattern] = handler
 }
+
 //a function to be called if the request is not a HTTP JSON RPC call
-func SetDefaultFunc(def func(http.ResponseWriter, *http.Request)){
-	mainMux.defaultFunction=def
+func SetDefaultFunc(def func(http.ResponseWriter, *http.Request)) {
+	mainMux.defaultFunction = def
 }
 
 //this is the funciton that should be called in order to answer an rpc call
 //should be registered like "http.HandleFunc("/", httpjsonrpc.Handle)"
-func Handle(w http.ResponseWriter, r *http.Request){
-	
+func Handle(w http.ResponseWriter, r *http.Request) {
+
 	//JSON RPC commands should be POSTs
-    if r.Method!="POST"{
-    	if mainMux.defaultFunction!=nil{
-    		log.Printf("HTTP JSON RPC Handle - Method!=\"POST\"")
-    		mainMux.defaultFunction(w, r)
-    		return
-    	} else {
-    		log.Panicf("HTTP JSON RPC Handle - Method!=\"POST\"")
-    		return
-    	}
-    }
-    
-    //We must check if there is Request Body to read
-    if r.Body==nil{
-    	if mainMux.defaultFunction!=nil{
-    		log.Printf("HTTP JSON RPC Handle - Request body is nil")
-    		mainMux.defaultFunction(w, r)
-    		return
-    	} else {
-    		log.Panicf("HTTP JSON RPC Handle - Request body is nil")
-    		return
-    	}
-    }
-	
+	if r.Method != "POST" {
+		if mainMux.defaultFunction != nil {
+			log.Printf("HTTP JSON RPC Handle - Method!=\"POST\"")
+			mainMux.defaultFunction(w, r)
+			return
+		} else {
+			log.Panicf("HTTP JSON RPC Handle - Method!=\"POST\"")
+			return
+		}
+	}
+
+	//We must check if there is Request Body to read
+	if r.Body == nil {
+		if mainMux.defaultFunction != nil {
+			log.Printf("HTTP JSON RPC Handle - Request body is nil")
+			mainMux.defaultFunction(w, r)
+			return
+		} else {
+			log.Panicf("HTTP JSON RPC Handle - Request body is nil")
+			return
+		}
+	}
+
 	//read the body of the request
-    body, err:= ioutil.ReadAll(r.Body)
-    //log.Println(r)
-    //log.Println(body)
-    if err!=nil{
-        log.Fatalf("HTTP JSON RPC Handle - ioutil.ReadAll: %v", err)
-        return
-    }
-    request := make(map[string]interface{})
-    //unmarshal the request
-    err = json.Unmarshal(body, &request)
-    if err != nil {
-        log.Fatalf("HTTP JSON RPC Handle - json.Unmarshal: %v", err)
-    	return
-    }
-    //log.Println(request["method"])
-    
-    //get the corresponding function
-    function, ok:=mainMux.m[request["method"].(string)]
-    
-    if ok{//if the function exists, itis called
-    	response:=function(r, request)
-    	//response from the program is encoded
-    	data, err := json.Marshal(response)
-    	if err!=nil{
-	        log.Fatalf("HTTP JSON RPC Handle - json.Marshal: %v", err)
-	        return
-    	}
-    	//result is printed to the output
-    	w.Write(data)
-    } else {//if the function does not exist
-    	log.Println("HTTP JSON RPC Handle - No function to call for", request["method"])
-    	/*
-    	//if you don't want to send an error, send something else:
-    	data, err := json.Marshal(map[string]interface{}{
-        	"result": "OK!",
-        	"error": nil,
-        	"id": request["id"],
-    	})*/
-    	//an error json is created
-    	data, err := json.Marshal(map[string]interface{}{
-        	"result": nil,
-        	"error": map[string]interface{}{
-        		"code": -32601,
-        		"message": "Method not found",
-        		"data": "The called method was not found on the server",
-        	
-        	},
-        	"id": request["id"],
-    	})
-    	if err!=nil{
-	        log.Fatalf("HTTP JSON RPC Handle - json.Marshal: %v", err)
-	        return
-    	}
+	body, err := ioutil.ReadAll(r.Body)
+	//log.Println(r)
+	//log.Println(body)
+	if err != nil {
+		log.Fatalf("HTTP JSON RPC Handle - ioutil.ReadAll: %v", err)
+		return
+	}
+	request := make(map[string]interface{})
+	//unmarshal the request
+	err = json.Unmarshal(body, &request)
+	if err != nil {
+		log.Fatalf("HTTP JSON RPC Handle - json.Unmarshal: %v", err)
+		return
+	}
+	//log.Println(request["method"])
+
+	//get the corresponding function
+	function, ok := mainMux.m[request["method"].(string)]
+
+	if ok { //if the function exists, itis called
+		response := function(r, request)
+		//response from the program is encoded
+		data, err := json.Marshal(response)
+		if err != nil {
+			log.Fatalf("HTTP JSON RPC Handle - json.Marshal: %v", err)
+			return
+		}
+		//result is printed to the output
+		w.Write(data)
+	} else { //if the function does not exist
+		log.Println("HTTP JSON RPC Handle - No function to call for", request["method"])
+		/*
+		   	//if you don't want to send an error, send something else:
+		   	data, err := json.Marshal(map[string]interface{}{
+		       	"result": "OK!",
+		       	"error": nil,
+		       	"id": request["id"],
+		   	})*/
+		//an error json is created
+		data, err := json.Marshal(map[string]interface{}{
+			"result": nil,
+			"error": map[string]interface{}{
+				"code":    -32601,
+				"message": "Method not found",
+				"data":    "The called method was not found on the server",
+			},
+			"id": request["id"],
+		})
+		if err != nil {
+			log.Fatalf("HTTP JSON RPC Handle - json.Marshal: %v", err)
+			return
+		}
 		//it is printed
-    	w.Write(data)
-    }
+		w.Write(data)
+	}
 }

--- a/httpjsonrpc/test.go
+++ b/httpjsonrpc/test.go
@@ -5,45 +5,44 @@ package httpjsonrpc
 // license that can be found in the LICENSE file.
 
 import (
-    "json"
-    "io/ioutil"
-    "log"
-    "http"
-    "strings"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
 )
 
-
-func Main(){
-	res, err:=Call("http://user:pass@127.0.0.1:8332", "getinfo", 1, []interface{}{})
-	if err!=nil{
-        log.Fatalf("Err: %v", err)
+func Main() {
+	res, err := Call("http://user:pass@127.0.0.1:8332", "getinfo", 1, []interface{}{})
+	if err != nil {
+		log.Fatalf("Err: %v", err)
 	}
 	log.Println(res)
 }
 
 func tmp() {
-    data, err := json.Marshal(map[string]interface{}{
-        "method": "getinfo",
-        "id":     1,
-        "params": []interface{}{},
-    })
-    if err != nil {
-        log.Fatalf("Marshal: %v", err)
-    }
-    resp, err := http.Post("http://user:pass@127.0.0.1:8332",
-        "application/json", strings.NewReader(string(data)))
-    if err != nil {
-        log.Fatalf("Post: %v", err)
-    }
-    defer resp.Body.Close()
-    body, err := ioutil.ReadAll(resp.Body)
-    if err != nil {
-        log.Fatalf("ReadAll: %v", err)
-    }
-    result := make(map[string]interface{})
-    err = json.Unmarshal(body, &result)
-    if err != nil {
-        log.Fatalf("Unmarshal: %v", err)
-    }
-    log.Println(result)
+	data, err := json.Marshal(map[string]interface{}{
+		"method": "getinfo",
+		"id":     1,
+		"params": []interface{}{},
+	})
+	if err != nil {
+		log.Fatalf("Marshal: %v", err)
+	}
+	resp, err := http.Post("http://user:pass@127.0.0.1:8332",
+		"application/json", strings.NewReader(string(data)))
+	if err != nil {
+		log.Fatalf("Post: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("ReadAll: %v", err)
+	}
+	result := make(map[string]interface{})
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		log.Fatalf("Unmarshal: %v", err)
+	}
+	log.Println(result)
 }


### PR DESCRIPTION
The httpjsonrpc code didn't build against the current go release (1.5), since the `http` and `json` packages were renamed to `net/http` and `encoding/json`, so I fixed it.

The code has also been reformatted slightly, since I also ran gofmt (vimgo does it automatically on save). I can redo the pull request without that if you prefer.
